### PR TITLE
fix: 이벤트리스너 중첩 현상 제거

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -14,16 +14,21 @@ export default function App({ $target }) {
 
     $target.innerHTML = "";
 
+    const $page = document.createElement("div");
+    $page.className = "page";
+    $target.appendChild($page);
+
     if (pathname === "/") {
-      new Home({ $target, props: { scoreManager } }).setup();
+      new Home({ $target: $page, props: { scoreManager } }).setup();
     } else if (pathname.indexOf("/cardGame/") === 0) {
       const [, , level] = pathname.split("/");
+
       new CardGame({
-        $target,
+        $target: $page,
         props: { level, scoreManager, timerManager },
       }).setup();
     } else if (pathname === "/result") {
-      new Result({ $target, props: { scoreManager } }).setup();
+      new Result({ $target: $page, props: { scoreManager } }).setup();
     }
   };
 

--- a/js/components/ProgressBar.js
+++ b/js/components/ProgressBar.js
@@ -8,7 +8,6 @@ export default function ProgressBar({ $target, props }) {
     this.render();
   };
 
-  // 타이머 함수
   this.template = () => {
     const { max, value } = this.state;
     return `<progress class="bar-style" max=${max} value=${value}></progress>`;

--- a/js/lib/service/TimerManager.js
+++ b/js/lib/service/TimerManager.js
@@ -6,7 +6,6 @@ export default function TimerManager(scoreManager) {
   this.clearTime;
 
   this.setTimer = (setState, limitTime) => {
-    if (this.timerId) return;
     this.timerId = setInterval(() => {
       if (!scoreManager.getScoreData().winOrLose) {
         this.clearTime = --limitTime;

--- a/js/pages/CardGame.js
+++ b/js/pages/CardGame.js
@@ -49,7 +49,6 @@ export default function CardGame({ $target, props }) {
 
   this.render = () => {
     $target.innerHTML = this.template();
-    this.mount();
   };
 
   this.setEvent = () => {
@@ -99,6 +98,7 @@ export default function CardGame({ $target, props }) {
 
   this.setup = () => {
     this.render();
+    this.mount();
     this.setEvent();
     scoreManager.initScoreData();
   };

--- a/js/pages/Home.js
+++ b/js/pages/Home.js
@@ -40,12 +40,10 @@ export default function Home({ $target, props }) {
   };
 
   this.setEvent = () => {
-    const $page = $target.querySelector(".home");
-
-    $page.addEventListener("click", (e) => {
+    $target.addEventListener("click", (e) => {
       e.preventDefault();
       if (e.target.tagName === "A") {
-        routeChange(e.target.href, e.target.dataset.level);
+        routeChange(e.target.href);
       }
     });
   };

--- a/js/pages/Result.js
+++ b/js/pages/Result.js
@@ -45,8 +45,8 @@ export default function Result({ $target, props }) {
         routeChange("/");
       }
       if (target.classList.contains("btn-return")) {
-        // routeChange("/cardGame/easy");
-        routeChange("/"); // 임시
+        routeChange("/cardGame/easy");
+        // routeChange("/"); // 임시
       }
     });
   };


### PR DESCRIPTION
## 작업내용

### 개요
- 게임을 재시작 할때 마운트가 반복되면서 ProgressBar, CardList 객체가 새로 생성되 타이머가 계속 반복되는 현상을 발견했습니다.
- root에 페이지 이동 시 이전에 있던 이벤트리스너가 제거되지 않아서 발생하는 현상으로 생각됩니다.
- 특정 이벤트 리스너나 다수의 이벤트 리스너를 지우는건 생각보다 까다로운 방법이어서 간단한 방법을 채택했습니다.이벤트 리스너가 걸려있는 DOM요소를 지우고 새로 생성하는 방법입니다.
- 기존에 root에 이벤트리스너를 추가하는 방식을 피하고 root 아래 `<div class="page"></div>` 요소를 생성해서 page에 이벤트리스너를 부착하고 페이지가 변경되면 제거하고 다시 page 요소를 생성하는 방법으로 진행했습니다.
```js
// app.js

  this.route = () => {
    const { pathname } = location;

    $target.innerHTML = "";

    const $page = document.createElement("div");
    $page.className = "page";
    $target.appendChild($page);

    if (pathname === "/") {
      new Home({ $target: $page, props: { scoreManager } }).setup();
    } 
    
   	...중략 
  }

```

## 스크린샷
### 이벤트 리스너 중첩으로 인한 메모리 누수
![메모리누수](https://user-images.githubusercontent.com/17325845/232201833-642ac507-f27a-4aa2-994e-5710bc93ac33.PNG)

### 참조하지 않는 이벤트 리스너를 가비지 컬렉터가 제거하는 모습
![image](https://user-images.githubusercontent.com/17325845/232202483-9cdfc332-8187-4747-82fa-1c95a5e78942.png)



